### PR TITLE
New GitHub Actions workflow files

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -26,25 +26,23 @@ jobs:
           fetch-depth: 0
       - name: Set GitLeaks Config
         run: |
+          if [[ ${{ github.REF }} == 'refs/heads'* ]]; then # This is a branch, not a pull request
+            CURRENT_COMMIT="${{ github.SHA }}"
+          else
+            CURRENT_COMMIT="${{ github.EVENT.PULL_REQUEST.HEAD.SHA }}"
+          fi
           echo "COMMITS=$(
-            git rev-list ${{ github.SHA }} ^origin/main | sed 's/^\|$//g' | paste -sd, -
+            git rev-list $CURRENT_COMMIT ^origin/main | sed 's/^\|$//g' | paste -sd, -
           )" >> $GITHUB_ENV
           echo "Title = 'GitLeaks Allowlist'" >> ${{ github.WORKSPACE }}/gitleaks.toml
           echo "[allowlist]" >> ${{ github.WORKSPACE }}/gitleaks.toml
           echo "  commits = ${{ env.GITLEAKS_CONFIG_COMMITS }}" >> ${{ github.WORKSPACE }}/gitleaks.toml
           echo "  regexes = ${{ env.GITLEAKS_CONFIG_REGEXES }}" >> ${{ github.WORKSPACE }}/gitleaks.toml
       - name: GitLeaks
-        uses: addnab/docker-run-action@v3
-        with:
-          image: zricethezav/gitleaks
-          options: -v ${{ github.WORKSPACE }}:/app
-          run: |
-            cd /app
-            if [[ ${{ github.REF }} == 'refs/heads/main' ]]; then
-              gitleaks --verbose --additional-config='gitleaks.toml' \
-                --repo-url='${{ github.SERVER_URL }}/${{ github.REPOSITORY }}' \
-                --access-token='${{ secrets.GITHUB_TOKEN }}'
-            else
-              gitleaks --verbose --additional-config='gitleaks.toml' \
-                --path='./' --commits='${{ env.COMMITS }}'
-            fi
+        run: |
+          COMMAND="gitleaks --verbose --additional-config='/app/gitleaks.toml' --path='/app'"
+          if [ ${{ github.REF }} != 'refs/heads/main' ]; then
+            COMMAND="${COMMAND} --commits='${{ env.COMMITS }}'"
+          fi
+          docker pull zricethezav/gitleaks
+          docker run --rm -v $(pwd):/app -i --entrypoint /bin/bash zricethezav/gitleaks -c "$COMMAND"


### PR DESCRIPTION
## Changes

Update the GitLeaks GH Action workflow file to match private template:

* Removing the pulling of the entire repository from GitHub URL will cut down on time. Not using a 3rd party GH Action will cut down on time. All of this practically lowers the time it takes to run this GH workflow from 1 min or more to like 30–40 seconds. Woohoo!

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue URL link
> * Pull Request URL link

## Additional Context

> Add any other context about the problem here.
